### PR TITLE
Feat: Detail Page Layout 및 국가 유산 detail page

### DIFF
--- a/src/components/DetailPageLayout.svelte
+++ b/src/components/DetailPageLayout.svelte
@@ -6,25 +6,29 @@
 
 <div class="min-h-screen bg-neutral-100 dark:bg-neutral-800">
   <!-- Header Image -->
-  <div class="relative h-64 lg:h-96 overflow-hidden">
-    <slot name="headerImage" />
-  </div>
-  <!-- svelte-ignore element_invalid_self_closing_tag -->
-  <div class="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
-  <!-- Prev Button -->
-  <Button
-    variant="ghost"
-    size="icon"
-    onclick={() => history.back()}
-    class="absolute top-4 left-4 bg-black/20 hover:bg-black/30 text-white"
+  <div
+    class="relative h-64 lg:h-96 overflow-hidden bg-linear-to-t from-black/50 to-black/20"
   >
-    <Fa icon={faArrowLeft} class="w-5 h-5" />
-  </Button>
-  <div class="absolute bottom-4 left-4 right-4 text-white">
-    <slot name="badges" />
-    <slot name="title" />
-    <div class="flex items-center gap-1 text-sm opacity-90">
-      <slot name="location" />
+    <slot name="headerImage" />
+    <!-- svelte-ignore element_invalid_self_closing_tag -->
+    <div
+      class="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"
+    />
+    <!-- Prev Button -->
+    <Button
+      variant="ghost"
+      size="icon"
+      onclick={() => history.back()}
+      class="absolute top-4 left-4 bg-black/20 hover:bg-black/30 text-white"
+    >
+      <Fa icon={faArrowLeft} class="w-5 h-5" />
+    </Button>
+    <div class="absolute bottom-4 left-4 right-4 text-white">
+      <slot name="badges" />
+      <slot name="title" />
+      <div class="flex items-center gap-1 text-sm opacity-90">
+        <slot name="location" />
+      </div>
     </div>
   </div>
   <div class="p-4">

--- a/src/components/DetailPageLayout.svelte
+++ b/src/components/DetailPageLayout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Badge } from '$/lib/components/ui/badge';
   import Button from '$/lib/components/ui/button/button.svelte';
   import { faArrowLeft, faMapPin } from '@fortawesome/free-solid-svg-icons';
   import Fa from 'svelte-fa';
@@ -7,12 +6,11 @@
 
 <div class="min-h-screen bg-neutral-100 dark:bg-neutral-800">
   <!-- Header Image -->
-  <div class="relative h-64 overflow-hidden">
+  <div class="relative h-64 lg:h-96 overflow-hidden">
     <slot name="headerImage" />
   </div>
-  <div
-    class="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"
-  ></div>
+  <!-- svelte-ignore element_invalid_self_closing_tag -->
+  <div class="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
   <!-- Prev Button -->
   <Button
     variant="ghost"
@@ -23,13 +21,15 @@
     <Fa icon={faArrowLeft} class="w-5 h-5" />
   </Button>
   <div class="absolute bottom-4 left-4 right-4 text-white">
-    <div class="flex items-center gap-2 mb-2">
-      <slot name="badges" />
-    </div>
+    <slot name="badges" />
     <slot name="title" />
     <div class="flex items-center gap-1 text-sm opacity-90">
-      <Fa icon={faMapPin} class="h-3 w-3" />
       <slot name="location" />
     </div>
+  </div>
+  <div class="p-4">
+    <slot name="details" />
+    <!-- Tabs -->
+    <slot />
   </div>
 </div>

--- a/src/components/ui/FallbackImage.svelte
+++ b/src/components/ui/FallbackImage.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  interface Props {
+    imageUrl?: string;
+    imageAlt?: string;
+  }
+
+  const { imageUrl, imageAlt }: Props = $props();
+
+  const ERROR_IMG_URL =
+    'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODgiIGhlaWdodD0iODgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBvcGFjaXR5PSIuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIzLjciPjxyZWN0IHg9IjE2IiB5PSIxNiIgd2lkdGg9IjU2IiBoZWlnaHQ9IjU2IiByeD0iNiIvPjxwYXRoIGQ9Im0xNiA1OCAxNi0xOCAzMiAzMiIvPjxjaXJjbGUgY3g9IjUzIiBjeT0iMzUiIHI9IjciLz48L3N2Zz4KCg==';
+</script>
+
+{#if imageUrl}
+  <img src={imageUrl} alt={imageAlt} class="w-full h-full object-cover" />
+{:else}
+  <div
+    class="inline-block bg-neutral-200 text-center align-middle w-full h-full object-cover"
+  >
+    <span class="flex items-center justify-center w-full h-full">
+      <img src={ERROR_IMG_URL} alt="Error" />
+    </span>
+  </div>
+{/if}

--- a/src/components/ui/ResultCard.svelte
+++ b/src/components/ui/ResultCard.svelte
@@ -6,6 +6,7 @@
     SearchedCcbaItem,
     SearchedMuseumItem,
   } from '$/types/search.types';
+  import FallbackImage from './FallbackImage.svelte';
 
   interface Props {
     ccba?: SearchedCcbaItem;
@@ -29,21 +30,7 @@
   <CardContent class="p-4">
     <div class="flex gap-3">
       <div class="w-20 h-20 rounded-lg overflow-hidden shrink-0">
-        {#if imageUrl}
-          <img
-            src={imageUrl}
-            alt={imageAlt}
-            class="w-full h-full object-cover"
-          />
-        {:else}
-          <div
-            class="inline-block bg-neutral-200 text-center align-middle w-full h-full object-cover"
-          >
-            <span class="flex items-center justify-center w-full h-full">
-              <img src={ERROR_IMG_URL} alt="Error" />
-            </span>
-          </div>
-        {/if}
+        <FallbackImage {imageUrl} {imageAlt} />
       </div>
       <div class="flex-1 min-w-0">
         <div class="flex items-start justify-between mb-2">

--- a/src/components/ui/ResultCard.svelte
+++ b/src/components/ui/ResultCard.svelte
@@ -22,10 +22,19 @@
   const imageUrl = type === 'ccba' ? ccba?.imageUrl : museum?.firstimage;
   const imageAlt = type === 'ccba' ? ccba?.ccimDesc : museum?.title;
   const title = type === 'ccba' ? ccba?.ccbaMnm1 : museum?.title;
+
+  function handleClick() {
+    if (type === 'ccba' && ccba) {
+      window.location.href = `/ccba?ccbaAsno=${ccba.ccbaAsno}&ccbaCtcd=${ccba.ccbaCtcd}&ccbaKdcd=${ccba.ccbaKdcd}`;
+    } else if (type === 'museum' && museum) {
+      // Navigate to museum detail page
+    }
+  }
 </script>
 
 <Card
   class="cursor-pointer hover:shadow-lg hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-shadow duration-200"
+  onclick={handleClick}
 >
   <CardContent class="p-4">
     <div class="flex gap-3">

--- a/src/components/ui/TextCollapse.svelte
+++ b/src/components/ui/TextCollapse.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { slide } from 'svelte/transition';
+
+  const {
+    text = '',
+    maxLines = 5,
+    showMoreText = 'Show More',
+    showLessText = 'Show Less',
+  } = $props();
+
+  let isCollapsed = $state(true);
+  let isOverflowing = $state(false);
+  // Reference to the text container
+  let textContainer = $state<HTMLDivElement | null>(null);
+  // Default max height
+  let maxHeight: number = $state(100);
+
+  onMount(() => {
+    if (textContainer) {
+      const computedStyle = window.getComputedStyle(textContainer);
+      const currentHeight = parseFloat(computedStyle.lineHeight);
+
+      maxHeight = currentHeight * maxLines;
+
+      isOverflowing = textContainer.scrollHeight > maxHeight;
+    }
+  });
+
+  function toggleCollapse() {
+    isCollapsed = !isCollapsed;
+  }
+</script>
+
+<div class="relative">
+  <div
+    class="overflow-hidden transition-all duration-400 relative"
+    bind:this={textContainer}
+    style="max-height: {isCollapsed
+      ? `${maxHeight}px`
+      : `${textContainer?.scrollHeight}px`}"
+  >
+    <p>{text}</p>
+  </div>
+
+  {#if isOverflowing}
+    <div class="relative w-full text-center items-center">
+      {#if isCollapsed}
+        <div
+          class="absolute left-0 bottom-0 z-10 right-0 h-20 pointer-events-none bg-linear-to-t from-white to-transparent dark:from-neutral-800"
+        ></div>
+      {/if}
+      <button
+        class="mt-2 text-blue-500 hover:underline focus:outline-none z-20 relative"
+        onclick={toggleCollapse}
+      >
+        {isCollapsed ? showMoreText : showLessText}
+      </button>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/ui/tabs/index.ts
+++ b/src/lib/components/ui/tabs/index.ts
@@ -1,0 +1,16 @@
+import Root from "./tabs.svelte";
+import Content from "./tabs-content.svelte";
+import List from "./tabs-list.svelte";
+import Trigger from "./tabs-trigger.svelte";
+
+export {
+	Root,
+	Content,
+	List,
+	Trigger,
+	//
+	Root as Tabs,
+	Content as TabsContent,
+	List as TabsList,
+	Trigger as TabsTrigger,
+};

--- a/src/lib/components/ui/tabs/tabs-content.svelte
+++ b/src/lib/components/ui/tabs/tabs-content.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: TabsPrimitive.ContentProps = $props();
+</script>
+
+<TabsPrimitive.Content
+	bind:ref
+	data-slot="tabs-content"
+	class={cn("flex-1 outline-none", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: TabsPrimitive.ListProps = $props();
+</script>
+
+<TabsPrimitive.List
+	bind:ref
+	data-slot="tabs-list"
+	class={cn(
+		"bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/tabs/tabs-trigger.svelte
+++ b/src/lib/components/ui/tabs/tabs-trigger.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: TabsPrimitive.TriggerProps = $props();
+</script>
+
+<TabsPrimitive.Trigger
+	bind:ref
+	data-slot="tabs-trigger"
+	class={cn(
+		"data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-sm font-medium transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/tabs/tabs.svelte
+++ b/src/lib/components/ui/tabs/tabs.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(""),
+		class: className,
+		...restProps
+	}: TabsPrimitive.RootProps = $props();
+</script>
+
+<TabsPrimitive.Root
+	bind:ref
+	bind:value
+	data-slot="tabs"
+	class={cn("flex flex-col gap-2", className)}
+	{...restProps}
+/>

--- a/src/routes/(details)/+layout.svelte
+++ b/src/routes/(details)/+layout.svelte
@@ -1,7 +1,35 @@
 <script lang="ts">
+  import { Badge } from '$/lib/components/ui/badge';
+  import Button from '$/lib/components/ui/button/button.svelte';
+  import { faArrowLeft, faMapPin } from '@fortawesome/free-solid-svg-icons';
+  import Fa from 'svelte-fa';
 </script>
 
-<!-- Header Image -->
 <div class="min-h-screen bg-neutral-100 dark:bg-neutral-800">
-  <slot />
+  <!-- Header Image -->
+  <div class="relative h-64 overflow-hidden">
+    <slot name="headerImage" />
+  </div>
+  <div
+    class="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent"
+  ></div>
+  <!-- Prev Button -->
+  <Button
+    variant="ghost"
+    size="icon"
+    onclick={() => history.back()}
+    class="absolute top-4 left-4 bg-black/20 hover:bg-black/30 text-white"
+  >
+    <Fa icon={faArrowLeft} class="w-5 h-5" />
+  </Button>
+  <div class="absolute bottom-4 left-4 right-4 text-white">
+    <div class="flex items-center gap-2 mb-2">
+      <slot name="badges" />
+    </div>
+    <slot name="title" />
+    <div class="flex items-center gap-1 text-sm opacity-90">
+      <Fa icon={faMapPin} class="h-3 w-3" />
+      <slot name="location" />
+    </div>
+  </div>
 </div>

--- a/src/routes/(details)/+layout.svelte
+++ b/src/routes/(details)/+layout.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+</script>
+
+<!-- Header Image -->
+<div class="min-h-screen bg-neutral-100 dark:bg-neutral-800">
+  <slot />
+</div>

--- a/src/routes/(details)/ccba/+page.server.ts
+++ b/src/routes/(details)/ccba/+page.server.ts
@@ -1,0 +1,38 @@
+import type { ccbaDtApiResponse } from '$/types/detail.types';
+import { XMLParser } from 'fast-xml-parser';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ url }) => {
+	const CCBA_DT_SEARCH_API_URL: string = 'http://www.khs.go.kr/cha/SearchKindOpenapiDt.do';
+
+	const ccbaKdcd = url.searchParams.get('ccbaKdcd') || '11';
+	const ccbaAsno = url.searchParams.get('ccbaAsno') || '0000030000000';
+	const ccbaCtcd = url.searchParams.get('ccbaCtcd') || '11';
+
+	let ccbaDetails: ccbaDtApiResponse | null = null;
+	let errorMsg: string | null = null;
+
+	try {
+		const response = await fetch(
+			`${CCBA_DT_SEARCH_API_URL}?ccbaKdcd=${ccbaKdcd}&ccbaAsno=${ccbaAsno}&ccbaCtcd=${ccbaCtcd}`
+		);
+
+		if (!response.ok) {
+			return { ccba: null, error: 'Failed to fetch CCBA details' };
+		}
+		const xml = await response.text();
+		ccbaDetails = parseXml(xml);
+	} catch (e) {
+		console.error('Error fetching CCBA details:', e);
+		errorMsg = 'Failed to load CCBA details';
+	}
+
+	return { ccba: ccbaDetails, error: errorMsg };
+};
+
+const parseXml = (xmlString: string): ccbaDtApiResponse => {
+	const parser: XMLParser = new XMLParser();
+	const jsonDoc = parser.parse(xmlString);
+
+	return jsonDoc.result;
+};

--- a/src/routes/(details)/ccba/+page.svelte
+++ b/src/routes/(details)/ccba/+page.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+</script>
+
+<slot />

--- a/src/routes/(details)/ccba/+page.svelte
+++ b/src/routes/(details)/ccba/+page.svelte
@@ -1,4 +1,141 @@
 <script lang="ts">
+  import DetailPageLayout from '$/components/DetailPageLayout.svelte';
+  import Badge from '$/lib/components/ui/badge/badge.svelte';
+  import type { ccbaDtApiResponse } from '$/types/detail.types';
+  import Fa from 'svelte-fa';
+  import type { PageData } from './$types';
+  import { faClock } from '@fortawesome/free-solid-svg-icons';
+  import * as Tabs from '$/lib/components/ui/tabs';
+  import * as Card from '$/lib/components/ui/card';
+  import TextCollapse from '$/components/ui/TextCollapse.svelte';
+
+  let { data }: { data: PageData } = $props();
+  const ccba: ccbaDtApiResponse | null = data.ccba;
+  const badges: string[] = [
+    ccba!.item.bcodeName,
+    ccba!.item.ccbaPoss,
+    ccba!.item.gcodeName,
+    ccba!.item.mcodeName,
+    ccba!.item.scodeName,
+  ];
+
+  // $effect(() => {
+  //   console.log(ccba);
+  // });
 </script>
 
-<slot />
+{#if ccba === null}
+  <div class="p-4">No data available.</div>
+{:else}
+  <DetailPageLayout>
+    <img
+      slot="headerImage"
+      src={ccba.item.imageUrl}
+      alt={ccba.item.ccmaName}
+      class="w-full lg:w-[80%] h-full object-cover lg:mx-auto"
+    />
+
+    <div slot="badges" class="flex items-center gap-2 mb-2">
+      <Badge variant="default">{ccba.item.ccmaName}</Badge>
+      {#each badges as badge (badge)}
+        <Badge variant="outline" class="text-white border-white">
+          {badge}
+        </Badge>
+      {/each}
+    </div>
+
+    <div slot="title" class="text-2xl mb-1">
+      <h1 class="text-2xl mb-1">
+        {ccba.item.ccbaMnm1}
+      </h1>
+      <h2 class="text-xl opacity-90">
+        ({ccba.item.ccbaMnm2})
+      </h2>
+    </div>
+
+    <div slot="location" class="flex items-center gap-1 text-sm opacity-90">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-6 w-6"
+        viewBox="0 0 24 24"
+      >
+        <circle cx="12" cy="9" r="2.5" fill="currentColor" fill-opacity="0">
+          <animate
+            fill="freeze"
+            attributeName="fill-opacity"
+            begin="0.7s"
+            dur="0.15s"
+            values="0;1"
+          />
+        </circle>
+        <path
+          fill="none"
+          stroke="currentColor"
+          stroke-dasharray="48"
+          stroke-dashoffset="48"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 20.5c0 0 -6 -7 -6 -11.5c0 -3.31 2.69 -6 6 -6c3.31 0 6 2.69 6 6c0 4.5 -6 11.5 -6 11.5Z"
+        >
+          <animate
+            fill="freeze"
+            attributeName="stroke-dashoffset"
+            dur="0.6s"
+            values="48;0"
+          />
+        </path>
+      </svg>
+      <span>{ccba.item.ccbaLcad}</span>
+    </div>
+
+    <div slot="details" class="p-4">
+      <div class="flex items-center gap-1 mb-6 text-sm text-muted-foreground">
+        <Fa icon={faClock} class="h-3 w-4" />
+        <span>{ccba.item.ccceName}</span>
+      </div>
+    </div>
+
+    <Tabs.Root value="overview" class="w-full">
+      <Tabs.List
+        class="grid w-full grid-cols-3 bg-neutral-300 dark:bg-neutral-900 px-1 py-1/2 rounded-full"
+      >
+        <Tabs.Trigger value="overview" class="rounded-full">
+          기본 정보
+        </Tabs.Trigger>
+        <Tabs.Trigger value="images" class="rounded-full">사진</Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="overview" class="mb-4">
+        <Card.Root>
+          <Card.Header>
+            <Card.Title>상세 정보</Card.Title>
+          </Card.Header>
+          <Card.Content class="mb-4">
+            <TextCollapse
+              text={ccba.item.content}
+              maxLines={5}
+              showLessText="접기"
+              showMoreText="더보기"
+            />
+
+            <div class="grid gird-cols-1 gap-4 text-sm">
+              <div></div>
+            </div>
+          </Card.Content>
+        </Card.Root>
+      </Tabs.Content>
+      <Tabs.Content value="images" class="mb-4">
+        <Card.Root>
+          <Card.Header>
+            <Card.Title>사진</Card.Title>
+          </Card.Header>
+          <Card.Content class="mb-4">
+            <div
+              class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
+            ></div>
+          </Card.Content>
+        </Card.Root>
+      </Tabs.Content>
+    </Tabs.Root>
+  </DetailPageLayout>
+{/if}

--- a/src/types/detail.types.ts
+++ b/src/types/detail.types.ts
@@ -1,0 +1,29 @@
+export type ccbaDtApiResponse = {
+	ccbaKdcd: string;
+	ccbaAsno: string;
+	ccbaCtcd: string;
+	ccbaCpno: string;
+	longitude: string;
+	latitude: string;
+	item: {
+		ccmaName: string;
+		ccbaMnm1: string;
+		ccbaMnm2: string;
+		gcodeName: string;
+		bcodeName: string;
+		mcodeName: string;
+		scodeName: string;
+		ccbaQuan: string;
+		ccbaAsdt: string;
+		ccbaCtcdNm: string;
+		ccsiName: string;
+		ccbaLcad: string;
+		ccceName: string;
+		ccbaPoss: string;
+		ccbaAdmin: string;
+		ccbaCncl: string;
+		ccbaCndt: string;
+		imageUrl: string;
+		content: string;
+	};
+};


### PR DESCRIPTION
- `src/lib/component/*` 경로에 있는 컴포넌트 8개는 `Shadcn-svelte/ui`를 통해 추가한 컴포넌트로, 리뷰 제외 대상
-  비어있는 파일 외 4개에 대해서만 리뷰 요청
- Detail Page의 Layout을 컴포넌트로 작성하고, ccba(국가유산)에 대해 상세 정보를 가져올 수 있도록 구성함
- `museum` 페이지에 대해서는 똑같이 작성한 뒤, DB 작업 이후 기능을 추가할 것으로 예상